### PR TITLE
Fix toggle action detection

### DIFF
--- a/isaac_auto_combat/main.lua
+++ b/isaac_auto_combat/main.lua
@@ -106,7 +106,7 @@ local function on_input_action(entity, hook, action)
 
   if player and hook == InputHook.IS_ACTION_TRIGGERED and action == state.config.toggleAction then
     local toggled = false
-    if Input.IsActionTriggered(action, player.ControllerIndex) and state.lastToggleFrame ~= state.frame then
+    if state.lastToggleFrame ~= state.frame then
       state.enabled = not state.enabled
       state.lastToggleFrame = state.frame
       toggled = true


### PR DESCRIPTION
## Summary
- remove the extra Input.IsActionTriggered guard so the toggle action fires reliably from the input hook
- keep the existing mode and intent reset logic when the combat handler is toggled

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d18c069fb88321a651e7d2e55158cf