### PR TITLE
Fix MC_INPUT_ACTION handler argument order

### DIFF
--- a/isaac_auto_combat/main.lua
+++ b/isaac_auto_combat/main.lua
@@ -90,7 +90,7 @@ local function on_post_new_room()
   reset_intent()
 end
 
-local function on_input_action(entity, hook, action)
+local function on_input_action(_, entity, hook, action)
   local player = entity and entity:ToPlayer()
   if player and player.ControllerIndex ~= 0 then
     return nil


### PR DESCRIPTION
## Summary
- ensure the MC_INPUT_ACTION callback ignores the mod argument so the entity, hook, and action parameters are correct

## Testing
- not run (game-dependent)

------
https://chatgpt.com/codex/tasks/task_e_68d194bda74c832186c771d034af07f1