### PR TITLE
Fix toggle ignoring keyboard controller index

### DIFF
--- a/isaac_auto_combat/main.lua
+++ b/isaac_auto_combat/main.lua
@@ -86,8 +86,11 @@ end
 
 local function on_input_action(_, entity, hook, action)
   local player = entity and entity:ToPlayer()
-  if player and player.ControllerIndex ~= 0 then
-    return nil
+  if player then
+    local controllerIndex = player.ControllerIndex or 0
+    if controllerIndex > 0 then
+      return nil
+    end
   end
 
   if player and hook == InputHook.IS_ACTION_PRESSED and action == state.config.toggleAction and state.enabled then


### PR DESCRIPTION
## Summary
- allow the toggle input handler to accept keyboard players so the default Tab binding works

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3af2dba2483219696a509f99c5569