### PR TITLE
Switch auto-combat toggle to G key

### DIFF
--- a/isaac_auto_combat/config/defaults.lua
+++ b/isaac_auto_combat/config/defaults.lua
@@ -1,6 +1,12 @@
 -- Default configuration values for the auto combat mod.
+local toggleKey = nil
+if Keyboard ~= nil then
+  toggleKey = Keyboard.KEY_G
+end
+
 return {
-  toggleAction = ButtonAction.ACTION_MAP,
+  toggleAction = nil,
+  toggleKey = toggleKey,
   overlay = {
     enabled = true,
     page = 1,


### PR DESCRIPTION
## Summary
- add a shared toggle helper and poll KEY_G each frame so the bot can be toggled with the keyboard
- keep optional action-based toggling while defaulting configuration to the G key with guards for missing globals

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3b3cb6434832182f28480bf7d8ec6